### PR TITLE
Sort files into alphabetical order before loading them

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Tell CustomJS what code to load.
 
 *Note: the folder setting will load all `*.js` files in that folder **recursively**. So setting `scripts` will load `scripts/a.js` and `scripts/other/b.js`*
 
+⚠️ Files are loaded in alphabetical order for consistency, enabling dependencies on each other.
+
 ## Usage/Example
 
 CustomJS works by writing javascript classes. Each file can only contain one class.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,9 @@ Tell CustomJS what code to load.
 
 **Individual files**: A comma-separated list of files you'd like to load.
 
-**Folder**: Path to a folder that contains JS files you'd like to load.
+**Folder**: Path to a folder that contains JS files you'd like to load. The folder setting will load all `*.js` files in that folder **recursively**. So setting `scripts` will load `scripts/a.js` and `scripts/other/b.js`.
 
-*Note: the folder setting will load all `*.js` files in that folder **recursively**. So setting `scripts` will load `scripts/a.js` and `scripts/other/b.js`*
-
-⚠️ Files are loaded in alphabetical order for consistency, enabling dependencies on each other.
+⚠️ Files are loaded in alphabetical order by ***file name*** for consistency, enabling dependencies on each other.
 
 ## Usage/Example
 

--- a/main.ts
+++ b/main.ts
@@ -61,7 +61,7 @@ export default class CustomJS extends Plugin {
 
     // Load individual files
     if (this.settings.jsFiles != '') {
-      const individualFiles = this.settings.jsFiles.split(',').map(s => s.trim());
+      const individualFiles = this.settings.jsFiles.split(',').map(s => s.trim()).sort();
       for (const f of individualFiles) {
         if (f != '' && f.endsWith('.js')) {
           await this.evalFile(f, customjs);
@@ -73,7 +73,8 @@ export default class CustomJS extends Plugin {
     if (this.settings.jsFolder != '') {
       const prefix = this.settings.jsFolder;
       const files = this.app.vault.getFiles();
-      const filesToLoad = files.filter(f => f.path.startsWith(prefix) && f.path.endsWith('.js'));
+      const filesToLoad = files.filter(f => f.path.startsWith(prefix) && f.path.endsWith('.js'))
+        .sort((a, b) => a.path.localeCompare(b.path));
       for (const f of filesToLoad) {
         if (f.path != '' && f.path.endsWith('.js')) {
           await this.evalFile(f.path, customjs);

--- a/main.ts
+++ b/main.ts
@@ -58,32 +58,48 @@ export default class CustomJS extends Plugin {
 
   async loadClasses() {
     const customjs = {}
+    const filesToLoad = [];
 
-    // Load individual files
+    // Get individual paths
     if (this.settings.jsFiles != '') {
       const individualFiles = this.settings.jsFiles.split(',').map(s => s.trim()).sort();
       for (const f of individualFiles) {
         if (f != '' && f.endsWith('.js')) {
-          await this.evalFile(f, customjs);
+          filesToLoad.push(f)
         }
       }
     }
 
-    // load scripts in folder
+    // Get paths in folder
     if (this.settings.jsFolder != '') {
       const prefix = this.settings.jsFolder;
       const files = this.app.vault.getFiles();
-      const filesToLoad = files.filter(f => f.path.startsWith(prefix) && f.path.endsWith('.js'))
-        .sort((a, b) => a.path.localeCompare(b.path));
-      for (const f of filesToLoad) {
-        if (f.path != '' && f.path.endsWith('.js')) {
-          await this.evalFile(f.path, customjs);
+      const scripts = files.filter(f => f.path.startsWith(prefix) && f.path.endsWith('.js'));
+
+      for (const s of scripts) {
+        if (s.path != '' && s.path.endsWith('.js')) {
+          filesToLoad.push(s.path);
         }
+      }
+
+      this.sortByFileName(filesToLoad);
+
+      // load all scripts
+      for (const f of filesToLoad) {
+        await this.evalFile(f, customjs);
       }
     }
 
     // @ts-ignore
     window.customJS = customjs;
+  }
+
+  sortByFileName(files: string[]) {
+    files.sort((a, b) => {
+      const nameA = a.split('/').last()
+      const nameB = b.split('/').last()
+      return nameA.localeCompare(nameB);
+    })
   }
 }
 


### PR DESCRIPTION
First off, thanks a bunch for this plugin - much more convenient than writing a full plugin of my own for making small improvements or extensions to Obsidian!

Currently, the two devices which I use Obsidian on load my JS files in a different order. Some of my scripts depend on others being loaded first, so this caused some problems. 

As an example, I created three new JS files, `a.js`, `b.js` and `c.js`:

- Linux laptop: c, b, a
- Android phone: c, a, b

This PR sorts the list of loaded files alphabetically by their full paths, so they load in a consistent order across all platforms. I've tested this on my laptop and phone and this change seems to work OK on both :)
