### PR TITLE
Make it Possible to Force CustomJS to Load Before Continuing

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,20 @@ class DvTasks {
 #### Result
 ![Result](images/dvTasksExample.png)
 
+### Asynchronous Usage
+
+CustomJS loads your modules at Obsidian's startup by hooking an event that says that Obsidian is ready. This is an event that is used by _other_ plugins as well (such as [Templater](https://github.com/SilentVoid13/Templater) and its startup template), and unfortunately this means that if you want to use CustomJS with them there can be problems. 
+
+> `customJS` is not defined
+
+If you see issues where the `customJS` variable is not defined, this is when you want to force it to load before your script continues. In order to allow this, we provide the asynchronous function `forceLoadCustomJS()`, also defined globally. This means that you can `await` it, thereby ensuring that `customJS` will be available when you need it.
+
+```js
+await forceLoadCustomJS();
+```
+
+That said, most of the time ___you do not need to do this___. In the vast majority of JavaScript execution taking place within Obsidian, customJS will be loaded.
+
 ## ☕️ Support
 Do you find CustomJS useful? Consider buying me a coffee to fuel updates and more useful software like this. Thank you!
 

--- a/main.ts
+++ b/main.ts
@@ -1,6 +1,12 @@
-import { App, Plugin, PluginSettingTab, Setting, TAbstractFile } from 'obsidian';
+import {
+  App,
+  Plugin,
+  PluginSettingTab,
+  Setting,
+  TAbstractFile,
+} from "obsidian";
 // @ts-ignore
-import compareVersions from 'compare-versions';
+import compareVersions from "compare-versions";
 
 interface CustomJSSettings {
   jsFiles: string;
@@ -8,20 +14,24 @@ interface CustomJSSettings {
 }
 
 const DEFAULT_SETTINGS: CustomJSSettings = {
-  jsFiles: '',
-  jsFolder: '',
-}
+  jsFiles: "",
+  jsFolder: "",
+};
 
 export default class CustomJS extends Plugin {
   settings: CustomJSSettings;
 
   async onload() {
-    console.log('Loading CustomJS');
+    console.log("Loading CustomJS");
     await this.loadSettings();
-    this.registerEvent(this.app.vault.on('modify', this.reloadIfNeeded, this))
+    this.registerEvent(this.app.vault.on("modify", this.reloadIfNeeded, this));
+    // @ts-ignore
+    window.forceLoadCustomJS = async () => {
+      await this.loadClasses();
+    };
     this.app.workspace.onLayoutReady(() => {
       this.loadClasses();
-    })
+    });
     this.addSettingTab(new CustomJSSettingsTab(this.app, this));
   }
 
@@ -31,14 +41,14 @@ export default class CustomJS extends Plugin {
   }
 
   async reloadIfNeeded(f: TAbstractFile) {
-    if (f.path.endsWith('.js')) {
+    if (f.path.endsWith(".js")) {
       await this.loadClasses();
 
       // reload dataviewjs blocks if installed & version >= 0.4.11
       if (this.app.plugins.enabledPlugins.has("dataview")) {
         // @ts-ignore
         const version = this.app.plugins.plugins?.dataview?.manifest.version;
-        if (compareVersions(version, '0.4.11') < 0) return;
+        if (compareVersions(version, "0.4.11") < 0) return;
 
         this.app.plugins.plugins.dataview?.api?.index?.touch();
       }
@@ -56,38 +66,43 @@ export default class CustomJS extends Plugin {
 
   async evalFile(f: string, customjs: any): Promise<void> {
     try {
-      const file = await this.app.vault.adapter.read(f)
-      const def = eval('(' + file + ')')
-      const cls = new def()
-      customjs[cls.constructor.name] = cls
+      const file = await this.app.vault.adapter.read(f);
+      const def = eval("(" + file + ")");
+      const cls = new def();
+      customjs[cls.constructor.name] = cls;
     } catch (e) {
-      console.error(`CustomJS couldn\'t import ${f}`)
-      console.error(e)
+      console.error(`CustomJS couldn\'t import ${f}`);
+      console.error(e);
     }
   }
 
   async loadClasses() {
-    const customjs = {}
+    const customjs = {};
     const filesToLoad = [];
 
     // Get individual paths
-    if (this.settings.jsFiles != '') {
-      const individualFiles = this.settings.jsFiles.split(',').map(s => s.trim()).sort();
+    if (this.settings.jsFiles != "") {
+      const individualFiles = this.settings.jsFiles
+        .split(",")
+        .map((s) => s.trim())
+        .sort();
       for (const f of individualFiles) {
-        if (f != '' && f.endsWith('.js')) {
-          filesToLoad.push(f)
+        if (f != "" && f.endsWith(".js")) {
+          filesToLoad.push(f);
         }
       }
     }
 
     // Get paths in folder
-    if (this.settings.jsFolder != '') {
+    if (this.settings.jsFolder != "") {
       const prefix = this.settings.jsFolder;
       const files = this.app.vault.getFiles();
-      const scripts = files.filter(f => f.path.startsWith(prefix) && f.path.endsWith('.js'));
+      const scripts = files.filter(
+        (f) => f.path.startsWith(prefix) && f.path.endsWith(".js")
+      );
 
       for (const s of scripts) {
-        if (s.path != '' && s.path.endsWith('.js')) {
+        if (s.path != "" && s.path.endsWith(".js")) {
           filesToLoad.push(s.path);
         }
       }
@@ -106,10 +121,10 @@ export default class CustomJS extends Plugin {
 
   sortByFileName(files: string[]) {
     files.sort((a, b) => {
-      const nameA = a.split('/').last()
-      const nameB = b.split('/').last()
+      const nameA = a.split("/").last();
+      const nameB = b.split("/").last();
       return nameA.localeCompare(nameB);
-    })
+    });
   }
 }
 
@@ -124,34 +139,36 @@ class CustomJSSettingsTab extends PluginSettingTab {
   display(): void {
     let { containerEl } = this;
     containerEl.empty();
-    containerEl.createEl('h2', { text: 'CustomJS' });
+    containerEl.createEl("h2", { text: "CustomJS" });
 
     // individual files
     new Setting(containerEl)
-      .setName('Individual files')
-      .setDesc('Comma-separated list of files to load')
-      .addText(text => text
-        .setPlaceholder('jsfile1.js,jsfile2.js')
-        .setValue(this.plugin.settings.jsFiles)
-        .onChange(async (value) => {
-          this.plugin.settings.jsFiles = value;
-          await this.plugin.saveSettings();
-          await this.plugin.loadClasses();
-        })
+      .setName("Individual files")
+      .setDesc("Comma-separated list of files to load")
+      .addText((text) =>
+        text
+          .setPlaceholder("jsfile1.js,jsfile2.js")
+          .setValue(this.plugin.settings.jsFiles)
+          .onChange(async (value) => {
+            this.plugin.settings.jsFiles = value;
+            await this.plugin.saveSettings();
+            await this.plugin.loadClasses();
+          })
       );
 
     // folder
     new Setting(containerEl)
-      .setName('Folder')
-      .setDesc('Path to folder containing JS files to load')
-      .addText(text => text
-        .setPlaceholder('js/scripts')
-        .setValue(this.plugin.settings.jsFolder)
-        .onChange(async (value) => {
-          this.plugin.settings.jsFolder = value;
-          await this.plugin.saveSettings();
-          await this.plugin.loadClasses();
-        })
+      .setName("Folder")
+      .setDesc("Path to folder containing JS files to load")
+      .addText((text) =>
+        text
+          .setPlaceholder("js/scripts")
+          .setValue(this.plugin.settings.jsFolder)
+          .onChange(async (value) => {
+            this.plugin.settings.jsFolder = value;
+            await this.plugin.saveSettings();
+            await this.plugin.loadClasses();
+          })
       );
   }
 }

--- a/main.ts
+++ b/main.ts
@@ -1,12 +1,6 @@
-import {
-  App,
-  Plugin,
-  PluginSettingTab,
-  Setting,
-  TAbstractFile,
-} from "obsidian";
+import { App, Plugin, PluginSettingTab, Setting, TAbstractFile } from 'obsidian';
 // @ts-ignore
-import compareVersions from "compare-versions";
+import compareVersions from 'compare-versions';
 
 interface CustomJSSettings {
   jsFiles: string;
@@ -14,17 +8,17 @@ interface CustomJSSettings {
 }
 
 const DEFAULT_SETTINGS: CustomJSSettings = {
-  jsFiles: "",
-  jsFolder: "",
-};
+  jsFiles: '',
+  jsFolder: '',
+}
 
 export default class CustomJS extends Plugin {
   settings: CustomJSSettings;
 
   async onload() {
-    console.log("Loading CustomJS");
+    console.log('Loading CustomJS');
     await this.loadSettings();
-    this.registerEvent(this.app.vault.on("modify", this.reloadIfNeeded, this));
+    this.registerEvent(this.app.vault.on('modify', this.reloadIfNeeded, this))
     // @ts-ignore
     window.forceLoadCustomJS = async () => {
       await this.loadClasses();
@@ -41,14 +35,14 @@ export default class CustomJS extends Plugin {
   }
 
   async reloadIfNeeded(f: TAbstractFile) {
-    if (f.path.endsWith(".js")) {
+    if (f.path.endsWith('.js')) {
       await this.loadClasses();
 
       // reload dataviewjs blocks if installed & version >= 0.4.11
       if (this.app.plugins.enabledPlugins.has("dataview")) {
         // @ts-ignore
         const version = this.app.plugins.plugins?.dataview?.manifest.version;
-        if (compareVersions(version, "0.4.11") < 0) return;
+        if (compareVersions(version, '0.4.11') < 0) return;
 
         this.app.plugins.plugins.dataview?.api?.index?.touch();
       }
@@ -66,43 +60,38 @@ export default class CustomJS extends Plugin {
 
   async evalFile(f: string, customjs: any): Promise<void> {
     try {
-      const file = await this.app.vault.adapter.read(f);
-      const def = eval("(" + file + ")");
-      const cls = new def();
-      customjs[cls.constructor.name] = cls;
+      const file = await this.app.vault.adapter.read(f)
+      const def = eval('(' + file + ')')
+      const cls = new def()
+      customjs[cls.constructor.name] = cls
     } catch (e) {
-      console.error(`CustomJS couldn\'t import ${f}`);
-      console.error(e);
+      console.error(`CustomJS couldn\'t import ${f}`)
+      console.error(e)
     }
   }
 
   async loadClasses() {
-    const customjs = {};
+    const customjs = {}
     const filesToLoad = [];
 
     // Get individual paths
-    if (this.settings.jsFiles != "") {
-      const individualFiles = this.settings.jsFiles
-        .split(",")
-        .map((s) => s.trim())
-        .sort();
+    if (this.settings.jsFiles != '') {
+      const individualFiles = this.settings.jsFiles.split(',').map(s => s.trim()).sort();
       for (const f of individualFiles) {
-        if (f != "" && f.endsWith(".js")) {
-          filesToLoad.push(f);
+        if (f != '' && f.endsWith('.js')) {
+          filesToLoad.push(f)
         }
       }
     }
 
     // Get paths in folder
-    if (this.settings.jsFolder != "") {
+    if (this.settings.jsFolder != '') {
       const prefix = this.settings.jsFolder;
       const files = this.app.vault.getFiles();
-      const scripts = files.filter(
-        (f) => f.path.startsWith(prefix) && f.path.endsWith(".js")
-      );
+      const scripts = files.filter(f => f.path.startsWith(prefix) && f.path.endsWith('.js'));
 
       for (const s of scripts) {
-        if (s.path != "" && s.path.endsWith(".js")) {
+        if (s.path != '' && s.path.endsWith('.js')) {
           filesToLoad.push(s.path);
         }
       }
@@ -121,10 +110,10 @@ export default class CustomJS extends Plugin {
 
   sortByFileName(files: string[]) {
     files.sort((a, b) => {
-      const nameA = a.split("/").last();
-      const nameB = b.split("/").last();
+      const nameA = a.split('/').last()
+      const nameB = b.split('/').last()
       return nameA.localeCompare(nameB);
-    });
+    })
   }
 }
 
@@ -139,36 +128,34 @@ class CustomJSSettingsTab extends PluginSettingTab {
   display(): void {
     let { containerEl } = this;
     containerEl.empty();
-    containerEl.createEl("h2", { text: "CustomJS" });
+    containerEl.createEl('h2', { text: 'CustomJS' });
 
     // individual files
     new Setting(containerEl)
-      .setName("Individual files")
-      .setDesc("Comma-separated list of files to load")
-      .addText((text) =>
-        text
-          .setPlaceholder("jsfile1.js,jsfile2.js")
-          .setValue(this.plugin.settings.jsFiles)
-          .onChange(async (value) => {
-            this.plugin.settings.jsFiles = value;
-            await this.plugin.saveSettings();
-            await this.plugin.loadClasses();
-          })
+      .setName('Individual files')
+      .setDesc('Comma-separated list of files to load')
+      .addText(text => text
+        .setPlaceholder('jsfile1.js,jsfile2.js')
+        .setValue(this.plugin.settings.jsFiles)
+        .onChange(async (value) => {
+          this.plugin.settings.jsFiles = value;
+          await this.plugin.saveSettings();
+          await this.plugin.loadClasses();
+        })
       );
 
     // folder
     new Setting(containerEl)
-      .setName("Folder")
-      .setDesc("Path to folder containing JS files to load")
-      .addText((text) =>
-        text
-          .setPlaceholder("js/scripts")
-          .setValue(this.plugin.settings.jsFolder)
-          .onChange(async (value) => {
-            this.plugin.settings.jsFolder = value;
-            await this.plugin.saveSettings();
-            await this.plugin.loadClasses();
-          })
+      .setName('Folder')
+      .setDesc('Path to folder containing JS files to load')
+      .addText(text => text
+        .setPlaceholder('js/scripts')
+        .setValue(this.plugin.settings.jsFolder)
+        .onChange(async (value) => {
+          this.plugin.settings.jsFolder = value;
+          await this.plugin.saveSettings();
+          await this.plugin.loadClasses();
+        })
       );
   }
 }


### PR DESCRIPTION
This PR introduces the global `forceLoadCustomJS` asynchronous function. Awaiting this function allows the user to ensure that the `customJS` variable is defined in their script when Obsidian's initialisation does not.

Closes #29.